### PR TITLE
fix: 2025/11/25が平日判定されるように

### DIFF
--- a/src/main/java/one/cafebabe/businesscalendar4j/Japan.java
+++ b/src/main/java/one/cafebabe/businesscalendar4j/Japan.java
@@ -191,6 +191,9 @@ public final class Japan {
                 if (!csv.holidayMap.containsKey(test) && (導出祝休日 == null || "japanese.休日".equals(導出祝休日))) {
                     break;
                 }
+                if ("japanese.休日".equals(導出祝休日) && csv.holidayMap.containsKey(test)) {
+                    break;
+                }
                 if (test.getDayOfWeek() == DayOfWeek.SUNDAY) {
                     return "japanese.休日";
                 }

--- a/src/main/java/one/cafebabe/businesscalendar4j/Japan.java
+++ b/src/main/java/one/cafebabe/businesscalendar4j/Japan.java
@@ -188,12 +188,10 @@ public final class Japan {
             while (test.getDayOfWeek() != DayOfWeek.SATURDAY) {
                 // is祝休日で調べるとカスタム祝休日も含めて振替休日を算出してしまうので注意
                 final String 導出祝休日 = this.apply(test);
-                if (!csv.holidayMap.containsKey(test) && (導出祝休日 == null || "japanese.休日".equals(導出祝休日))) {
+                if ((!csv.holidayMap.containsKey(test) && 導出祝休日 == null) || "japanese.休日".equals(導出祝休日)) {
                     break;
                 }
-                if ("japanese.休日".equals(導出祝休日) && csv.holidayMap.containsKey(test)) {
-                    break;
-                }
+
                 if (test.getDayOfWeek() == DayOfWeek.SUNDAY) {
                     return "japanese.休日";
                 }

--- a/src/test/java/one/cafebabe/businesscalendar4j/BusinessCalendarTest.java
+++ b/src/test/java/one/cafebabe/businesscalendar4j/BusinessCalendarTest.java
@@ -60,7 +60,9 @@ class BusinessCalendarTest {
                 // Labor Thanksgiving Day
                 () -> assertFalse(calendar.isBusinessDay(LocalDate.of(2021, 11, 23))),
                 // normal business day
-                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2021, 12, 31)))
+                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2021, 12, 31))),
+                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2025, 5, 7))),
+                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2025, 11, 25)))
 
         );
     }
@@ -213,7 +215,11 @@ class BusinessCalendarTest {
     @Test
     void getCabinetOfficialHolidayDataFirstLastDay() {
         assertEquals(LocalDate.of(1955, 1, 1), Japan.getCabinetOfficialHolidayDataFirstDay());
-        assertEquals(LocalDate.of(LocalDate.now().getYear() + 1, 11, 23), Japan.getCabinetOfficialHolidayDataLastDay());
+//        assertEquals(LocalDate.of(LocalDate.now().getYear() + 1, 11, 23), Japan.getCabinetOfficialHolidayDataLastDay());
+        assertEquals(
+                LocalDate.of(LocalDate.now().getYear() + 1, 11, LocalDate.of(LocalDate.now().getYear() + 1, 11, 23).getDayOfWeek() == DayOfWeek.SUNDAY ? 24 : 23),
+                Japan.getCabinetOfficialHolidayDataLastDay()
+        );
     }
 
     @Test

--- a/src/test/java/one/cafebabe/businesscalendar4j/BusinessCalendarTest.java
+++ b/src/test/java/one/cafebabe/businesscalendar4j/BusinessCalendarTest.java
@@ -42,7 +42,11 @@ class BusinessCalendarTest {
                 // Labor Thanksgiving Day
                 () -> assertTrue(calendar.isHoliday(LocalDate.of(2021, 11, 23))),
                 // normal business day
-                () -> assertFalse(calendar.isHoliday(LocalDate.of(2021, 12, 31)))
+                () -> assertFalse(calendar.isHoliday(LocalDate.of(2021, 12, 31))),
+                () -> assertTrue(calendar.isHoliday(LocalDate.of(2025, 5, 3))),
+                () -> assertTrue(calendar.isHoliday(LocalDate.of(2025, 5, 6))),
+                () -> assertTrue(calendar.isHoliday(LocalDate.of(2025, 11, 3))),
+                () -> assertTrue(calendar.isHoliday(LocalDate.of(2026, 11, 23)))
 
         );
     }
@@ -61,9 +65,11 @@ class BusinessCalendarTest {
                 () -> assertFalse(calendar.isBusinessDay(LocalDate.of(2021, 11, 23))),
                 // normal business day
                 () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2021, 12, 31))),
+                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2025, 5, 2))),
                 () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2025, 5, 7))),
-                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2025, 11, 25)))
-
+                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2025, 11, 4))),
+                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2025, 11, 25))),
+                () -> assertTrue(calendar.isBusinessDay(LocalDate.of(2026, 11, 24)))
         );
     }
 
@@ -215,11 +221,10 @@ class BusinessCalendarTest {
     @Test
     void getCabinetOfficialHolidayDataFirstLastDay() {
         assertEquals(LocalDate.of(1955, 1, 1), Japan.getCabinetOfficialHolidayDataFirstDay());
-//        assertEquals(LocalDate.of(LocalDate.now().getYear() + 1, 11, 23), Japan.getCabinetOfficialHolidayDataLastDay());
-        assertEquals(
-                LocalDate.of(LocalDate.now().getYear() + 1, 11, LocalDate.of(LocalDate.now().getYear() + 1, 11, 23).getDayOfWeek() == DayOfWeek.SUNDAY ? 24 : 23),
-                Japan.getCabinetOfficialHolidayDataLastDay()
-        );
+
+        LocalDate laborThanksgivingDay = LocalDate.of(LocalDate.now().getYear() + 1, 11, 23);
+        LocalDate lastDay = laborThanksgivingDay.getDayOfWeek() == DayOfWeek.SUNDAY ? laborThanksgivingDay.plusDays(1) : laborThanksgivingDay;
+        assertEquals(lastDay, Japan.getCabinetOfficialHolidayDataLastDay());
     }
 
     @Test


### PR DESCRIPTION
### 概要
```
BusinessCalendar calendar = BusinessCalendar.newBuilder()
            .holiday(BusinessCalendar.JAPAN.PUBLIC_HOLIDAYS)
            .build()

calendar.isHoliday(LocalDate.of(2025, 11, 25))
=> true
```

2025/11/23（日）は勤労感謝の日
2025/11/24（月）は祝日法第3条第2項による休日

ですが、2025/11/25（火）は平日になると思うので、祝休日と判定されないように修正をしています。
